### PR TITLE
Detect circular references

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,66 +4,106 @@
 const pico = require('picocolors')
 
 module.exports = () => {
-	let cache = {}
 	return {
 		postcssPlugin: 'postcss-at-apply',
-		AtRule       : {
-			apply: (rule, {result}) => {
-				const classes = rule.params.replace(' !important', '').split(/[\s\t\n]+/g);
-				const root    = rule.root();
-				const rules   = new Set();
-				for (let name of classes) {
-					const selector = name.startsWith('.') ? name : `.${name}`
-					if (!(selector in cache)) {
-						root.walk(child => {
-							if (child.type === 'rule' && child.selectors.includes(selector)) {
-								cache[selector] = child
-							}
-						});
-					}
+		Once(root, {result})
+		{
+			const cache     = new Map;
+			const map       = new Map;
+			const need      = new Set;
+			const recursion = new Set;
+			const seen      = new Set;
 
+			root.walkAtRules('apply', atRule => {
+				atRule.parent.selectors.forEach(selector => { !map.has(selector) && map.set(selector, new Set); });
+				atRule.params.replace(' !important', '').split(/[\s\t\n]+/g).forEach(name => {
+					atRule.parent.selectors.forEach(key => {
+						map.get(key).add(name.startsWith('.') ? name : `.${name}`)
+					});
+				})
+			});
+
+			map.forEach((_, key) => scanForRecursion(key, seen));
+			map.forEach(value => value.forEach(need.add, need));
+			root.walkRules(child => {
+				for (let selector of child.selectors.filter(x => need.has(x))) {
+					cache[selector] = child;
+				}
+			});
+
+			// we didn't cache the atRule... maybe we should have?
+			root.walkAtRules('apply', (atRule) => {
+				const rules = new Set;
+				for (let name of atRule.params.replace(' !important', '').split(/[\s\t\n]+/g)) {
+					let selector = name.startsWith('.') ? name : `.${name}`;
 					if (selector in cache) {
-						for (const node of cache[selector].nodes) {
-							rules.add(node.toString());
+						for (let node of cache[selector].nodes) {
+							rules.add(node.clone());
 						}
 					}
+					else if (recursion.has(`${atRule.parent.selector}-${selector}`)) {
+						result.warn(warningHighlight(atRule, name, 'Circular reference detected', 'circular reference'));
+					}
 					else {
-						result.warn(warningHighlight(rule, name));
+						result.warn(warningHighlight(atRule, name, 'Rule not found in css', 'not found'));
 					}
 				}
 
-				if (rules.size > 0) {
-					rule.replaceWith(...rules);
+				let parent = atRule.parent;
+				atRule.replaceWith(...rules);
+				if (!parent.nodes || parent.nodes.length === 0) {
+					// should a warning be emitted that we removed the parent?
+					parent.remove();
 				}
+			});
+
+			function scanForRecursion(selector, seen)
+			{
+				if (seen.has(selector)) {
+					return true;
+				}
+
+				seen.add(selector);
+				for (let applySelector of (map.get(selector) || [])) {
+					if (scanForRecursion(applySelector, new Set(seen))) {
+						map.get(selector).delete(applySelector);
+						recursion.add(`${selector}-${applySelector}`);
+						return true;
+					}
+				}
+
+				return false;
 			}
 		}
 	};
 };
 
 /**
- * @param {Rule}   rule    The rule to use for formatting
- * @param {string} search The string to search for
+ * @param {Rule}   rule          The rule to use for formatting
+ * @param {string} search       The string to search for
+ * @param {string} description Describe the warning
+ * @param {string} message      Message for the arrow highlight
  *
  * @returns {string} The formatted warning
  */
-function warningHighlight(rule, search)
+function warningHighlight(rule, search, description, message)
 {
-	const re = new RegExp("\\b" + search + "\\b");
+	const re    = new RegExp("\\b" + search + "\\b");
 	const match = rule.params.match(re);
 	if (!match) {
 		return '';
 	}
 
 	return [
-		pico.reset() + '',
-		pico.yellow("WARNING: ") + 'Rule not found in css',
+		pico.reset(''),
+		pico.yellow("WARNING: ") + description,
 		'',
 		pico.blue(' | ') + (rule.source.input.file || rule.source.input.css),
 		pico.blue(` | ${rule.parent.selector} {`),
 		pico.blue(' |   @apply ') + rule.params.replace(re, pico.red(search)),
-		pico.blue(' |          ') + ' '.repeat(match.index) + pico.red('^'.repeat(search.length) + ' not found'),
+		pico.blue(' |          ') + ' '.repeat(match.index) + pico.red('^'.repeat(search.length) + ` ${message}`),
 		pico.blue(` | }`),
 	].join('\n');
-}
+ }
 
 module.exports.postcss = true;

--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
       "consistent-return": "error",
       "curly": "error",
       "eqeqeq": "error",
-      "guard-for-in": "error"
+      "guard-for-in": "error",
+      "no-mixed-spaces-and-tabs": ["error", "smart-tabs"]
     },
     "extends": [
       "eslint:recommended"

--- a/tests/index.js
+++ b/tests/index.js
@@ -30,27 +30,50 @@ test('warning on missing', t => {
 	const ps = postcss(apply({debug: true})).process('.a{@apply z kakaw b} .b{color:blue}');
 	for (const w of ps.warnings()) {
 		// we can't rely on indexOf due to CLI colorization
-		t.notEqual(-1, w.text.indexOf("Rule not found in css"), 'has "Rule not found in css"');
+		t.ok(w.text.includes("Rule not found in css"), 'has "Rule not found in css" warning');
 	}
 
-	t.equal(ps.css.trim(), '.a{color:blue} .b{color:blue}');
+	t.equal(ps.css.trim(), '.a{color:blue} .b{color:blue}', '.a contains .b');
 	t.end();
 });
 
 test('group of selectors', t => {
 	const ps = postcss(apply({debug: true})).process('.a, .c {color:red} .b{@apply a}');
-	t.equal(ps.css.trim(), '.a, .c {color:red} .b{color:red}');
+	t.equal(ps.css.trim(), '.a, .c {color:red} .b{color:red}', 'contains .a');
 	t.end();
 });
 
 test('group of selector with non-class prefix ', t => {
 	const ps = postcss(apply({debug: true})).process('div.a {color:blue} .a, .c {color:red} .b{@apply a}');
-	t.equal(ps.css.trim(), 'div.a {color:blue} .a, .c {color:red} .b{color:red}');
+	t.equal(ps.css.trim(), 'div.a {color:blue} .a, .c {color:red} .b{color:red}', 'contains .a');
 	t.end();
 });
 
 test('rule selector with > ', t => {
 	const ps = postcss(apply({debug: true})).process('.a, .c {color:red} div > .a {color:blue} .b{@apply a}');
-	t.equal(ps.css.trim(), '.a, .c {color:red} div > .a {color:blue} .b{color:red}');
+	t.equal(ps.css.trim(), '.a, .c {color:red} div > .a {color:blue} .b{color:red}', 'contains .a');
+	t.end();
+});
+
+
+test('skips reference to self', t => {
+	const ps = postcss(apply({debug: true})).process('.a, .c {color:red} .b{@apply a b}');
+	for (const w of ps.warnings()) {
+		t.ok(w.text.includes('Circular reference detected'), 'has "Circular reference detected" warning');
+	}
+	t.equal(ps.css.trim(), '.a, .c {color:red} .b{color:red}', 'contains .a');
+	t.end();
+});
+
+test('skips reference to self', t => {
+	const ps = postcss(apply({debug: true})).process('.z { @apply a b } .a, .c {color:red} .b { @apply z }');
+	let i = 0;
+	for (const w of ps.warnings()) {
+		// there should be 2 of these
+		i++;
+		t.ok(w.text.includes('Circular reference detected'), 'has "Circular reference detected" warning');
+	}
+	t.equal(2, i, "found 2 warnings");
+	t.equal(ps.css.trim(), '.z {color:red} .a, .c {color:red}', 'missing .b');
 	t.end();
 });


### PR DESCRIPTION
This fixes #6 and emits a warning similar to when the selector is not found.